### PR TITLE
reordered route delete and route create

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -344,20 +344,20 @@ def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
 
     changed = bool(routes_to_delete or route_specs_to_create)
     if changed:
-        for route_spec in route_specs_to_create:
-            try:
-                vpc_conn.create_route(route_table.id,
-                                      dry_run=check_mode,
-                                      **route_spec)
-            except EC2ResponseError as e:
-                if e.error_code == 'DryRunOperation':
-                    pass
-
         for route in routes_to_delete:
             try:
                 vpc_conn.delete_route(route_table.id,
                                       route.destination_cidr_block,
                                       dry_run=check_mode)
+            except EC2ResponseError as e:
+                if e.error_code == 'DryRunOperation':
+                    pass
+
+        for route_spec in route_specs_to_create:
+            try:
+                vpc_conn.create_route(route_table.id,
+                                      dry_run=check_mode,
+                                      **route_spec)
             except EC2ResponseError as e:
                 if e.error_code == 'DryRunOperation':
                     pass


### PR DESCRIPTION
Hi Etherdaemon,

I noticed something while using your changes. If a NAT instance has been used as a default gateway and that instance is deleted, it shows up as "Black Hole" in the AWS console.  This is "null" and the NoneType error that this fix addresses.

However, if a new NAT instance is created is specified as the gateway using this module, it will only delete the blackhole route and it will not add the new route to the new instance. Rerunning the playbook/module will create the route.

If I reorder the delete and route_spec for loops, it will both delete the blackhole and create the new NAT instance route in one play.

I'm not sure of the unintended consequences of this change, but it seems to work for what I need. Let me know if it's useful.

Cheers,
Bill
