### PR TITLE
Fixed wrong parameter passed to vpc endpoint module functions

### DIFF
--- a/cloud/amazon/ec2_vpc_endpoint_facts.py
+++ b/cloud/amazon/ec2_vpc_endpoint_facts.py
@@ -184,7 +184,7 @@ def main():
         'services': get_supported_services,
         'endpoints': get_endpoints,
     }
-    results = invocations[module.params.get('query')](ec2, module)
+    results = invocations[module.params.get('query')](connection, module)
 
     module.exit_json(result=results)
 


### PR DESCRIPTION
Old code was using the ec2 boto2 syntax which made it break.

CC: @Etherdaemon 
